### PR TITLE
Gate Console Logs and Centralize Debug Flag for Production Cleanliness

### DIFF
--- a/src/components/workspace/WorkspaceEditor.tsx
+++ b/src/components/workspace/WorkspaceEditor.tsx
@@ -84,13 +84,15 @@ const WorkspaceEditorComponent = memo(function WorkspaceEditor({
     const { markFileDirty } = useWorkspaceStore();
 
     // Debug logging
-    console.log('WorkspaceEditor render:', {
-        fileId,
-        fileType,
-        hasData: !!fileData,
-        isLoading,
-        error: error?.message,
-    });
+    if (process.env.NODE_ENV === 'development') {
+        console.log('WorkspaceEditor render:', {
+            fileId,
+            fileType,
+            hasData: !!fileData,
+            isLoading,
+            error: error?.message,
+        });
+    }
 
     // Handle content changes with auto-save
     const handleContentChange = useCallback((updates: any) => {

--- a/src/lib/fileCache.ts
+++ b/src/lib/fileCache.ts
@@ -23,7 +23,7 @@ const FILE_SELECTED = 'file:selected';
 const FILE_SAVED = 'file:saved';
 
 // Debug mode for logging cache operations
-const DEBUG = false;
+const DEBUG = process.env.NODE_ENV === 'development';
 
 /**
  * Log cache operations if debug mode is enabled


### PR DESCRIPTION
## PR: Code Quality - Gate Debugging and Centralize Flag

Hello!

I am submitting this Pull Request to address the issue of debug code impacting production builds, ensuring a clean and optimal deployment. As a first-time contributor, I enjoyed contributing this maintenance fix!

### Changes Implemented

This PR fixes debug code across two files and verifies the state of a third, meeting all acceptance criteria:

| File | Change | Acceptance Criteria Met |
| :--- | :--- | :--- |
| **`src/lib/fileCache.ts`** | Replaced the hardcoded `const DEBUG = false` with **`const DEBUG = process.env.NODE_ENV === 'development'`**. | The `DEBUG` flag now correctly uses environment variables, ensuring logs are automatically disabled and removed in production. |
| **`src/components/workspace/WorkspaceEditor.tsx`** | Wrapped the redundant `console.log` statements in a conditional block: **`if (process.env.NODE_ENV === 'development')`**. | Debug logging is now correctly gated and will not appear in production builds. |
| **`src/components/canvas/ShapeConnector.tsx`** | **Verified** that the debug visualization for hover zones was **already correctly gated** with `process.env.NODE_ENV === 'development'`. No functional changes were required for this file. | Debug zones were confirmed to be properly gated. |

### Verification & Commit

I've ensured these changes will result in:
* Clean console output in production.
* Debug features only enabled in development mode.
* The codebase adheres to best practices by centralizing the debug state via `NODE_ENV`.

Please let me know if any further changes or testing are required!

Thank you for the opportunity to contribute.